### PR TITLE
Add ".." as a dedicated concat operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ xcuserdata/
 # Dart stuff.
 /tool/.dart_tool/
 /tool/.packages
+
+/java/com/craftinginterpreters/lox/.idea/
+/java/com/craftinginterpreters/lox/lox.iml
+/java/com/craftinginterpreters/lox/out/

--- a/java/com/craftinginterpreters/lox/Interpreter.java
+++ b/java/com/craftinginterpreters/lox/Interpreter.java
@@ -299,24 +299,24 @@ class Interpreter implements Expr.Visitor<Object>,
         checkNumberOperands(expr.operator, left, right);
 //< check-minus-operand
         return (double)left - (double)right;
-//> binary-plus
       case PLUS:
-        if (left instanceof Double && right instanceof Double) {
-          return (double)left + (double)right;
-        } // [plus]
+//> check-plus-operand
+        checkNumberOperands(expr.operator, left, right);
+        return (double)left + (double)right;
+//< check-plus-operand
+      case CONCAT:
+//> check-concat-operand
+        String outLeft = "";
+        String outRight = "";
+        if (left instanceof Double) outLeft = Double.toString((double)left);
+        if (right instanceof Double) outRight = Double.toString((double)right);
+        outLeft = outLeft.replaceAll("\\.0$", "");
+        outRight = outRight.replaceAll("\\.0", "");
+        if (left instanceof String) outLeft = (String) left;
+        if (right instanceof String) outRight = (String) right;
 
-        if (left instanceof String && right instanceof String) {
-          return (String)left + (String)right;
-        }
-
-/* Evaluating Expressions binary-plus < Evaluating Expressions string-wrong-type
-        break;
-*/
-//> string-wrong-type
-        throw new RuntimeError(expr.operator,
-            "Operands must be two numbers or two strings.");
-//< string-wrong-type
-//< binary-plus
+        return outLeft + outRight;
+//< check-concat-operand
       case SLASH:
 //> check-slash-operand
         checkNumberOperands(expr.operator, left, right);

--- a/java/com/craftinginterpreters/lox/Parser.java
+++ b/java/com/craftinginterpreters/lox/Parser.java
@@ -372,7 +372,7 @@ class Parser {
   private Expr term() {
     Expr expr = factor();
 
-    while (match(MINUS, PLUS)) {
+    while (match(MINUS, PLUS, CONCAT)) {
       Token operator = previous();
       Expr right = factor();
       expr = new Expr.Binary(expr, operator, right);
@@ -433,7 +433,6 @@ class Parser {
 //> Functions call
   private Expr call() {
     Expr expr = primary();
-
     while (true) { // [while-true]
       if (match(LEFT_PAREN)) {
         expr = finishCall(expr);
@@ -447,7 +446,6 @@ class Parser {
         break;
       }
     }
-
     return expr;
   }
 //< Functions call

--- a/java/com/craftinginterpreters/lox/Scanner.java
+++ b/java/com/craftinginterpreters/lox/Scanner.java
@@ -64,7 +64,6 @@ class Scanner {
       case '{': addToken(LEFT_BRACE); break;
       case '}': addToken(RIGHT_BRACE); break;
       case ',': addToken(COMMA); break;
-      case '.': addToken(DOT); break;
       case '-': addToken(MINUS); break;
       case '+': addToken(PLUS); break;
       case ';': addToken(SEMICOLON); break;
@@ -81,6 +80,9 @@ class Scanner {
         break;
       case '>':
         addToken(match('=') ? GREATER_EQUAL : GREATER);
+        break;
+      case '.':
+        addToken(match('.') ? CONCAT : DOT);
         break;
 //< two-char-tokens
 //> slash

--- a/java/com/craftinginterpreters/lox/TokenType.java
+++ b/java/com/craftinginterpreters/lox/TokenType.java
@@ -4,13 +4,14 @@ package com.craftinginterpreters.lox;
 enum TokenType {
   // Single-character tokens.
   LEFT_PAREN, RIGHT_PAREN, LEFT_BRACE, RIGHT_BRACE,
-  COMMA, DOT, MINUS, PLUS, SEMICOLON, SLASH, STAR,
+  COMMA, MINUS, PLUS, SEMICOLON, SLASH, STAR,
 
   // One or two character tokens.
   BANG, BANG_EQUAL,
   EQUAL, EQUAL_EQUAL,
   GREATER, GREATER_EQUAL,
   LESS, LESS_EQUAL,
+  DOT, CONCAT,
 
   // Literals.
   IDENTIFIER, STRING, NUMBER,


### PR DESCRIPTION
Instead of overloading "+", add ".." as a dedicated operator for concat. I prefer Lua's two dots over PHP's one dot and this is also easier to implement I think. Right now only numbers and strings are supported, but you can concat two numbers if you want and get a string output. This is a more consistent language design than being able to concat one string and one number and have it return a string as suggested in one of the challenges I think, and I like having a dedicated concat operator.